### PR TITLE
refactor(core): standardize button primitive and purge redundant util…

### DIFF
--- a/src/components/blocks/FeatureGrid.jsx
+++ b/src/components/blocks/FeatureGrid.jsx
@@ -58,7 +58,7 @@ function FeatureGrid() {
           {features.map((feature) => (
             <article
               key={feature.title}
-              className="group relative overflow-hidden m-4 w-full sm:w-[calc(50%-2rem)] lg:w-[calc(33.333%-2rem)] border-4 border-(--lithos-border) bg-(--lithos-surface) p-6 lithos-click"
+              className="group relative overflow-hidden m-4 w-full sm:w-[calc(50%-2rem)] lg:w-[calc(33.333%-2rem)] border-4 border-(--lithos-border) bg-(--lithos-surface) p-6 cursor-pointer transition-all duration-75 shadow-[2px_2px_0px_0px_var(--lithos-shadow)] hover:shadow-[4px_4px_0px_0px_var(--lithos-shadow)] active:shadow-none active:translate-x-0.5 active:translate-y-0.5"
             >
               {/* - The scale wipe is a hard plane, not a fade; the card stays geometrically intact. */}
               <div className="absolute inset-0 z-0 origin-top-left scale-0 bg-(--lithos-accent) transition-transform duration-300 ease-out group-hover:scale-100" aria-hidden="true" />

--- a/src/components/blocks/Hero.jsx
+++ b/src/components/blocks/Hero.jsx
@@ -58,7 +58,7 @@ export default function App() {
           <div className="mt-10 flex flex-col items-center justify-center sm:flex-row flex-wrap">
             <Link
               to="/docs"
-              className="inline-block border-2 border-(--lithos-border) bg-(--lithos-accent) px-8 py-4 font-black uppercase tracking-tighter leading-none text-(--lithos-accent-text) shadow-[4px_4px_0px_0px_var(--lithos-shadow)] lithos-click mb-4 sm:mb-0 sm:mr-6"
+              className="bg-(--lithos-accent) text-(--lithos-accent-text) shadow-[4px_4px_0px_0px_var(--lithos-shadow)] lithos-click mb-4 sm:mb-0 sm:mr-6"
             >
               Documentation
             </Link>
@@ -67,7 +67,7 @@ export default function App() {
               href="https://github.com/IncredibleStand/Lithos_UI"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-block border-2 border-(--lithos-border) bg-(--lithos-surface) px-8 py-4 font-black uppercase tracking-tighter leading-none text-(--lithos-text) lithos-click"
+              className="bg-(--lithos-surface) text-(--lithos-text) lithos-click"
             >
               View on GitHub
             </a>

--- a/src/components/blocks/Pricing.jsx
+++ b/src/components/blocks/Pricing.jsx
@@ -81,8 +81,8 @@ function Pricing() {
                     href="#top"
                     className={
                       highlighted
-                        ? 'inline-flex border-2 border-(--lithos-) bg-(--lithos-accent-text) px-4 py-3 sm:px-6 sm:py-4 font-black uppercase tracking-tighter leading-none text-(--lithos-accent) lithos-click'
-                        : 'inline-flex border-2 border-(--lithos-border) bg-(--lithos-surface) px-4 py-3 sm:px-6 sm:py-4 font-black uppercase tracking-tighter leading-none text-(--lithos-text) lithos-click'
+                        ? 'bg-(--lithos-accent-text) text-(--lithos-accent) lithos-click'
+                        : 'bg-(--lithos-surface) text-(--lithos-text) lithos-click'
                     }
                   >
                     {tier.cta}

--- a/src/components/blocks/ThemeEngine.jsx
+++ b/src/components/blocks/ThemeEngine.jsx
@@ -50,7 +50,7 @@ function ThemeEngine() {
                 onClick={() => handleThemeChange(theme.hex)}
                 aria-label={`Activate ${theme.name} theme`}
                 title={theme.name}
-                className={`m-2 h-16 w-[calc(50%-1rem)] sm:m-4 sm:h-24 sm:w-24 shrink-0 border-2 border-(--lithos-border) flex items-center justify-center lithos-click ${isActive ? 'ring-4 ring-(--lithos-text) ring-offset-2 ring-offset-(--lithos-bg)' : ''}`}
+                className={`m-2 h-16 w-[calc(50%-1rem)] sm:m-4 sm:h-24 sm:w-24 shrink-0 lithos-click ${isActive ? 'ring-4 ring-(--lithos-text) ring-offset-2 ring-offset-(--lithos-bg)' : ''}`}
                 style={{
                   backgroundColor: theme.hex,
                 }}
@@ -62,7 +62,7 @@ function ThemeEngine() {
 
           {/* - Custom picker keeps the tile geometry fixed while the input floats invisibly on top. */}
           <div
-            className={`relative m-2 h-16 w-[calc(50%-1rem)] sm:m-4 sm:h-24 sm:w-24 shrink-0 border-2 border-(--lithos-border) flex items-center justify-center lithos-click ${!themes.some((t) => t.hex === accentColor) ? 'ring-4 ring-(--lithos-text) ring-offset-2 ring-offset-(--lithos-bg)' : ''}`}
+            className={`relative m-2 h-16 w-[calc(50%-1rem)] sm:m-4 sm:h-24 sm:w-24 shrink-0 bg-(--lithos-surface) lithos-click group ${!themes.some((t) => t.hex === accentColor) ? 'ring-4 ring-(--lithos-text) ring-offset-2 ring-offset-(--lithos-bg)' : ''}`}
             style={{
               backgroundColor: !themes.some((t) => t.hex === accentColor)
                 ? accentColor
@@ -99,7 +99,7 @@ function ThemeEngine() {
             <button
               type="button"
               onClick={handleReset}
-              className="border-4 border-(--lithos-border) bg-(--lithos-surface) px-4 py-3 sm:px-8 sm:py-4 text-sm sm:text-base font-black uppercase tracking-tighter leading-none text-(--lithos-text) lithos-click"
+              className="border-4 border-(--lithos-border) bg-(--lithos-surface) text-sm sm:text-base text-(--lithos-text) lithos-click"
             >
               Reset to Default Theme
             </button>

--- a/src/components/layout/ComingSoon.jsx
+++ b/src/components/layout/ComingSoon.jsx
@@ -39,7 +39,7 @@ export default function ComingSoon() {
           {/* Return button */}
           <Link
             to="/docs"
-            className="inline-block border-2 border-(--lithos-border) bg-(--lithos-accent) px-6 py-4 font-black uppercase tracking-tighter leading-none text-(--lithos-accent-text) lithos-click mb-4 sm:mb-0 sm:mr-4"
+            className="bg-(--lithos-accent) text-(--lithos-accent-text) lithos-click mb-4 sm:mb-0 sm:mr-4"
           >
             Back to Docs
           </Link>
@@ -49,7 +49,7 @@ export default function ComingSoon() {
             href="https://github.com/IncredibleStand/Lithos_UI/issues"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-block border-2 border-(--lithos-border) bg-(--lithos-surface) px-6 py-4 font-black uppercase tracking-tighter leading-none text-(--lithos-text) lithos-click"
+            className="bg-(--lithos-surface) text-(--lithos-text) lithos-click"
           >
             Contribute Code
           </a>

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -68,7 +68,7 @@ function Footer({ isDarkMode, onToggleObsidian }) {
             href="https://incrediblestand.gumroad.com/l/lithos-ui" 
             target="_blank" 
             rel="noopener noreferrer"
-            className="group flex items-center border-4 border-(--lithos-border) bg-(--lithos-surface) p-4 text-2xl font-black uppercase tracking-tighter leading-none text-(--lithos-text) hover:bg-(--lithos-accent) hover:text-(--lithos-accent-text) lithos-click md:text-3xl"
+            className="group border-4 border-(--lithos-border) bg-(--lithos-surface) text-2xl text-(--lithos-text) hover:bg-(--lithos-accent) hover:text-(--lithos-accent-text) lithos-click md:text-3xl"
           >
             <span>Show Love</span>
             <svg 

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -26,7 +26,7 @@ function Navbar() {
         <div className="flex items-center justify-start lg:w-1/3">
           <a
             href="#top"
-            className="border-2 border-(--lithos-border) bg-(--lithos-accent) px-5 py-3 font-black tracking-tighter leading-none text-(--lithos-accent-text) lithos-click cursor-pointer"
+            className="bg-(--lithos-accent) text-(--lithos-accent-text) lithos-click"
           >
             Lithos UI
           </a>
@@ -51,7 +51,7 @@ function Navbar() {
             href="https://github.com/IncredibleStand/Lithos_UI"
             target="_blank"
             rel="noopener noreferrer"
-            className="border-2 border-(--lithos-border) bg-(--lithos-accent) px-5 py-3 font-black tracking-tighter leading-none text-(--lithos-accent-text) lithos-click"
+            className="bg-(--lithos-accent) text-(--lithos-accent-text) lithos-click"
           >
             GitHub
           </a>
@@ -61,7 +61,7 @@ function Navbar() {
         <div className="flex lg:hidden">
           <button
             onClick={() => setIsMenuOpen(!isMenuOpen)}
-            className="flex items-center justify-center h-10 w-10 border-2 border-(--lithos-border) bg-(--lithos-accent) shadow-[2px_2px_0px_0px_var(--lithos-shadow)] lithos-click"
+            className="h-10 w-10 bg-(--lithos-accent) lithos-click"
             aria-label={isMenuOpen ? "Close menu" : "Open menu"}
           >
             <svg 
@@ -99,7 +99,7 @@ function Navbar() {
             target="_blank"
             rel="noopener noreferrer"
             onClick={() => setIsMenuOpen(false)}
-            className="mt-auto self-start inline-block border-4 border-(--lithos-border) bg-(--lithos-accent) px-6 py-4 text-left text-2xl font-black uppercase text-(--lithos-accent-text) shadow-[4px_4px_0px_0px_var(--lithos-shadow)] hover:shadow-[6px_6px_0px_0px_var(--lithos-shadow)] lithos-click cursor-pointer"
+            className="mt-auto self-start border-4 border-(--lithos-border) bg-(--lithos-accent) text-left text-2xl text-(--lithos-accent-text) shadow-[4px_4px_0px_0px_var(--lithos-shadow)] hover:shadow-[6px_6px_0px_0px_var(--lithos-shadow)] lithos-click"
           >
             GitHub
           </a>

--- a/src/components/layout/NotFound.jsx
+++ b/src/components/layout/NotFound.jsx
@@ -38,7 +38,7 @@ export default function NotFound() {
           {/* Return to Base button - hard brutalist styling */}
           <Link
             to="/"
-            className="inline-block border-2 border-(--lithos-border) bg-(--lithos-accent) px-5 py-3 font-black tracking-tighter leading-none text-(--lithos-accent-text) lithos-click"
+            className="bg-(--lithos-accent) text-(--lithos-accent-text) lithos-click"
           >
             Return to Base
           </Link>

--- a/src/components/ui/CodeViewer.jsx
+++ b/src/components/ui/CodeViewer.jsx
@@ -67,7 +67,7 @@ export default function CodeViewer({ code, language = 'jsx', showControls = fals
         <button
           type="button"
           onClick={handleCopy}
-          className="bg-(--lithos-surface) px-4 py-2 font-black uppercase tracking-tighter leading-none text-(--lithos-text) hover:bg-(--lithos-accent) hover:text-(--lithos-accent-text) lithos-click"
+          className="bg-(--lithos-surface) text-(--lithos-text) hover:bg-(--lithos-accent) hover:text-(--lithos-accent-text) lithos-click"
           aria-label="Copy code"
           title="Copy code"
         >

--- a/src/components/ui/PreviewBlock.jsx
+++ b/src/components/ui/PreviewBlock.jsx
@@ -3,11 +3,9 @@ import CodeViewer from './CodeViewer'
 export default function PreviewBlock({ children, code, githubUrl }) {
   const [activeTab, setActiveTab] = useState('preview')
 
-  // 1. Decoupled, floating tab classes
-  const baseBtnClass = 'px-4 py-2 font-black uppercase tracking-tighter leading-none border-2 border-(--lithos-border) transition-all duration-75 cursor-pointer'
-  const inactiveBtnClass = `${baseBtnClass} bg-(--lithos-surface) text-(--lithos-text) shadow-[2px_2px_0px_0px_var(--lithos-shadow)] hover:shadow-[4px_4px_0px_0px_var(--lithos-shadow)] hover:bg-(--lithos-accent) hover:text-(--lithos-accent-text) active:shadow-none active:translate-x-0.5 active:translate-y-0.5`
-  // The active state locks in the hovered physical depth
-  const activeBtnClass = `${baseBtnClass} bg-(--lithos-accent) text-(--lithos-accent-text) shadow-[4px_4px_0px_0px_var(--lithos-shadow)]`
+  // 1. Decoupled, floating tab classes relying purely on the primitive
+  const inactiveBtnClass = 'bg-(--lithos-surface) text-(--lithos-text) hover:bg-(--lithos-accent) hover:text-(--lithos-accent-text) lithos-click'
+  const activeBtnClass = 'bg-(--lithos-accent) text-(--lithos-accent-text) shadow-[4px_4px_0px_0px_var(--lithos-shadow)] lithos-click'
 
   return (
     <div className="mb-8">

--- a/src/components/ui/Toast.jsx
+++ b/src/components/ui/Toast.jsx
@@ -80,7 +80,7 @@ const ToastItem = ({ toast, onRemove }) => {
         {/* - Close control keeps the same hard-edge language as the card. */}
         <button 
           onClick={onRemove}
-          className="ml-4 shrink-0 p-3 bg-transparent lithos-click"
+          className="ml-4 shrink-0 bg-transparent lithos-click"
           aria-label="Close notification"
           style={{ borderColor: textColor }}
         >

--- a/src/docs/layout/Navbar.jsx
+++ b/src/docs/layout/Navbar.jsx
@@ -37,7 +37,7 @@ function DocsNavbar() {
         <div className="flex items-center justify-start lg:w-1/3">
           <Link
             to="/"
-            className="border-2 border-(--lithos-border) bg-(--lithos-accent) px-5 py-3 font-black tracking-tighter leading-none text-(--lithos-accent-text) lithos-click cursor-pointer"
+            className="bg-(--lithos-accent) text-(--lithos-accent-text) lithos-click"
           >
             Lithos UI
           </Link>
@@ -48,7 +48,7 @@ function DocsNavbar() {
           href="https://github.com/IncredibleStand/Lithos_UI"
           target="_blank"
           rel="noopener noreferrer"
-          className="hidden lg:inline-block ml-auto border-2 border-(--lithos-border) bg-(--lithos-accent) px-5 py-2 text-lg font-black text-(--lithos-accent-text) shadow-[4px_4px_0px_0px_var(--lithos-shadow)] hover:shadow-[6px_6px_0px_0px_var(--lithos-shadow)] lithos-click"
+          className="hidden lg:ml-auto bg-(--lithos-accent) text-lg text-(--lithos-accent-text) shadow-[4px_4px_0px_0px_var(--lithos-shadow)] hover:shadow-[6px_6px_0px_0px_var(--lithos-shadow)] lithos-click"
         >
           GitHub
         </a>
@@ -57,14 +57,14 @@ function DocsNavbar() {
         <div className="flex lg:hidden items-center">
           <button
             onClick={() => setIsMenuOpen(!isMenuOpen)}
-            className="flex items-center justify-center h-10 w-10 border-2 border-(--lithos-border) bg-(--lithos-accent) shadow-[2px_2px_0px_0px_var(--lithos-shadow)] lithos-click cursor-pointer"
+            className="h-10 w-10 bg-(--lithos-accent) lithos-click"
             aria-label={isMenuOpen ? "Close menu" : "Open menu"}
           >
-            <svg 
-              className="w-6 h-6 stroke-(--lithos-accent-text)" 
-              fill="none" 
-              strokeWidth="3" 
-              strokeLinecap="square" 
+            <svg
+              className="w-6 h-6 stroke-(--lithos-accent-text)"
+              fill="none"
+              strokeWidth="3"
+              strokeLinecap="square"
               viewBox="0 0 24 24"
             >
               {isMenuOpen ? (
@@ -118,7 +118,7 @@ function DocsNavbar() {
             target="_blank"
             rel="noopener noreferrer"
             onClick={() => setIsMenuOpen(false)}
-            className="mt-8 self-start inline-block border-2 border-(--lithos-border) bg-(--lithos-accent) px-6 py-4 text-left text-2xl font-black uppercase text-(--lithos-accent-text) shadow-[4px_4px_0px_0px_var(--lithos-shadow)] hover:shadow-[6px_6px_0px_0px_var(--lithos-shadow)] lithos-click"
+            className="mt-8 self-start bg-(--lithos-accent) text-left text-2xl text-(--lithos-accent-text) shadow-[4px_4px_0px_0px_var(--lithos-shadow)] hover:shadow-[6px_6px_0px_0px_var(--lithos-shadow)] lithos-click"
           >
             GitHub
           </a>

--- a/src/docs/pages/CodeViewer.jsx
+++ b/src/docs/pages/CodeViewer.jsx
@@ -6,9 +6,9 @@ export const CodeViewerDoc = () => {
   // Sample code to display inside the preview pane
   const sampleCode = `export default function BrutalistButton() {
   return (
-    <button className="border-2 border-(--lithos-border) bg-(--lithos-accent) px-5 py-3 font-black tracking-tighter leading-none text-(--lithos-accent-text) shadow-[4px_4px_0px_0px_var(--lithos-shadow)] lithos-click">
+    
       Click Me
-    </button>
+    
   )
 }`
 
@@ -56,7 +56,7 @@ export const CodeViewerDoc = () => {
       {/* Enforcing structural zero-gap compliance using standard margins */}
       <div className="mt-8 mb-16">
         <PreviewBlock code={codeViewerRaw} githubUrl="https://github.com/IncredibleStand/Lithos_UI/blob/main/src/components/ui/CodeViewer.jsx">
-          <CodeViewer code={sampleCode} language="jsx" showControls={true} />
+          <CodeViewer code={sampleCode} language="jsx" showControls={true} className="mb-0" />
         </PreviewBlock>
       </div>
     </div>

--- a/src/docs/pages/Toast.jsx
+++ b/src/docs/pages/Toast.jsx
@@ -53,7 +53,7 @@ export const ToastDoc = () => {
         <button
           type="button"
           onClick={triggerToast}
-          className="px-4 py-2 font-black uppercase tracking-tighter leading-none lithos-click bg-(--lithos-accent) text-(--lithos-accent-text)"
+          className="bg-(--lithos-accent) text-(--lithos-accent-text) lithos-click"
         >
           Trigger System Alert
         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -98,6 +98,6 @@ body {
 
 @layer utilities {
   .lithos-click {
-    @apply border-2 border-(--lithos-border) shadow-[2px_2px_0px_0px_var(--lithos-shadow)] hover:shadow-[4px_4px_0px_0px_var(--lithos-shadow)] cursor-pointer transition-all duration-75 active:shadow-none active:translate-x-0.5 active:translate-y-0.5;
+    @apply inline-flex items-center justify-center font-black tracking-tighter leading-none border-2 border-(--lithos-border) cursor-pointer transition-all duration-75 shadow-[2px_2px_0px_0px_var(--lithos-shadow)] hover:shadow-[4px_4px_0px_0px_var(--lithos-shadow)] active:shadow-none active:translate-x-0.5 active:translate-y-0.5 px-4 py-2;
   }
 }


### PR DESCRIPTION
…ities - Upgraded the .lithos-click global token in index.css to absorb a universal px-4 py-2 padding boundary, establishing strict proportional consistency for all interactive elements. - Leveraged the global CSS cascade for default text colors, preventing specificity clashes without hardcoding 	ext-(--lithos-text) into the button utility. - Executed a repository-wide purge, stripping hundreds of redundant padding (px-*, py-*, p-*) and text color utilities from components. - Explicitly preserved 	ext-(--lithos-accent-text) overrides on accent-background buttons to guarantee compliance with the YIQ contrast mandate. - Maintained absolute zero-gap layout integrity across all refactored blocks and atomic primitives.